### PR TITLE
Support symfony 4.0 too

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -25,7 +25,7 @@
         "php": ">=7.1",
         "typo3/cms-core": "^8.7 || ^9.5",
         "lightsaml/lightsaml": "^1.4",
-        "symfony/http-foundation": "^3.4"
+        "symfony/http-foundation": "^3.4 || ^4.0"
     },
     "require-dev": {
         "saschaegerer/phpstan-typo3": "*@dev",


### PR DESCRIPTION
This adds support for Symfony 4 too. As our projects and TYPO3 core extensions use Symfony 4 already. There are no BC breaks in the http-foundation components affecting this extension.

IMHO the support for Symfony 3 could be dropped, as the TYPO3 core extensions require only ^4.1 symfony components mostly. It's just luck, that it never crashed, cause no TYPO3 core extension required the http-foundation, but we do in our projects :)