### PR TITLE
Bump symfony

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -25,7 +25,7 @@
         "php": ">=7.1",
         "typo3/cms-core": "^9.5",
         "lightsaml/lightsaml": "^1.4",
-        "symfony/http-foundation": "^3.4"
+        "symfony/http-foundation": "^4.1"
     },
     "require-dev": {
         "saschaegerer/phpstan-typo3": "*@dev",


### PR DESCRIPTION
TYPO3 ships already with symfony 4.1 so we can upgrade our symfony version to 4.1 as well.