### PR TITLE
Fix fetching from values from PhpSession

### DIFF
--- a/Classes/Session/PhpSession.php
+++ b/Classes/Session/PhpSession.php
@@ -87,7 +87,7 @@ class PhpSession implements SingletonInterface
     {
         $this->start();
 
-        if (\array_key_exists($key, $_SESSION[self::SESSION_KEY])) {
+        if (! \array_key_exists($key, $_SESSION[self::SESSION_KEY])) {
             return null;
         }
 

--- a/Classes/Session/PhpSession.php
+++ b/Classes/Session/PhpSession.php
@@ -87,7 +87,7 @@ class PhpSession implements SingletonInterface
     {
         $this->start();
 
-        if (! \array_key_exists($key, $_SESSION[self::SESSION_KEY])) {
+        if (!\array_key_exists($key, $_SESSION[self::SESSION_KEY])) {
             return null;
         }
 


### PR DESCRIPTION
Previously empty() was used. When it was replaced by array_key_exists() the negation was missed.