### PR TITLE
Activate signing and encryption for auth request.

### DIFF
--- a/Classes/Container/PartyContainer.php
+++ b/Classes/Container/PartyContainer.php
@@ -35,9 +35,13 @@ class PartyContainer implements PartyContainerInterface, SingletonInterface
 
     public function getTrustOptionsStore()
     {
+        $trustOptions = new TrustOptions();
+        $trustOptions->setSignAuthnRequest(true);
+        $trustOptions->setEncryptAuthnRequest(true);
+
         /** @var FixedTrustOptionsStore $trustStore */
         $trustStore = $this->container->getInstance(FixedTrustOptionsStore::class);
-        $trustStore->setTrustOptions(new TrustOptions());
+        $trustStore->setTrustOptions($trustOptions);
 
         return $trustStore;
     }

--- a/Classes/Store/CredentialStore.php
+++ b/Classes/Store/CredentialStore.php
@@ -28,9 +28,8 @@ class CredentialStore implements CredentialStoreInterface, SingletonInterface
         $qb = $this->pool->getQueryBuilderForTable('tx_mksamlauth_domain_model_identityprovider');
         $qb->select('*');
         $qb->from('tx_mksamlauth_domain_model_identityprovider');
-        $qb->where($qb->expr()->eq('idp_entity_id', '?'));
+        $qb->where($qb->expr()->eq('name', $qb->createNamedParameter($entityId)));
         $qb->setMaxResults(1);
-        $qb->setParameters([$entityId]);
 
         if (false === $stmt = $qb->execute()) {
             return null;
@@ -39,6 +38,7 @@ class CredentialStore implements CredentialStoreInterface, SingletonInterface
         if (false === $row = $stmt->fetch()) {
             return null;
         }
+
 
         $certificate = new X509Certificate();
         $certificate->loadPem($row['certificate']);


### PR DESCRIPTION
This is a security issue. The title says it all.

The variable $trustOptions should be prospectively outscored from the PartyContainer. It should be configurable. But because the fix has to be done quickly, here is a quick and dirty one.