### PR TITLE
Fix authUser function for using multiple authentication services.

### DIFF
--- a/Classes/Authentication/SamlAuth.php
+++ b/Classes/Authentication/SamlAuth.php
@@ -65,7 +65,12 @@ class SamlAuth extends AuthenticationService
 
     public function authUser(array $user): int
     {
-        return \is_array($this->configuration) ? 200 : 0;
+        try {
+            return $this->receive()->getUid() === $user['uid'] ? 200 : 100;
+        }
+        catch (MissingConfigurationException $exception) {
+            return 100;
+        }
     }
 
     private function receive(): FrontendUser


### PR DESCRIPTION
@hannesbochmann: The try - and catch logic should be removed in perspective. It should always be determined that the $configuration variable is set. But as an intermediate solution the code covers all cases. 